### PR TITLE
texi/Makefile: don't create dvi files when running "make clean"

### DIFF
--- a/texi/Makefile
+++ b/texi/Makefile
@@ -38,7 +38,7 @@ dvi: $(DVIFILES) clean
 html:
 	$(PERL) $(TEXI2HTML) $(TEXI2FLAG) $(SOURCES)
 
-clean: $(DVIFILES)
+clean:
 	'rm' -f *.aux *.cp *.fn *.ky *.log *.pg *.toc *.tp *.vr *.fns *.cps *.vrs
 
 distclean:


### PR DESCRIPTION
If you run `make distclean` and then `make clean`, you'll see that dvi files get built by the latter, which seems wrong.