### PR TITLE
Some cleanup in and related to texi/Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,11 @@
 *.cp
 *.cps
 *.dvi
+*.pdf
 *.fn
 *.fns
 *.log
 *.toc
 *.info
+*.vr
+*.vrs

--- a/texi/Makefile
+++ b/texi/Makefile
@@ -1,4 +1,5 @@
 # 'make info' produces info files, as does 'make texinfo'
+# 'make pdf' produces pdf files and lots of crap, then erases the crap
 # 'make dvi' produces dvi files and lots of crap, then erases the crap
 # 'make all' produces both info and dvi files, and cleans up afterwards
 # 'make install' copies the info files to /usr/local/info (or the value
@@ -12,28 +13,37 @@
 #     PERL=
 #  
 SOURCES = light.texi ultra.texi
+PDFFILES = light.pdf ultra.pdf
 DVIFILES = light.dvi ultra.dvi
 INFOFILES = light.info ultra.info
 #
 TEXI2HTML=texi2html
 PERL=perl
 #
+TEXI2PDF=texi2pdf
 TEXI2DVI=texi2dvi
 MAKEINFO=makeinfo
 TEXI2FLAG=-menu -split_chapter 
 INFODIR=/usr/local/info
 
-all: texinfo dvi
+all: texinfo pdf
 
 info: texinfo
 
 texinfo:
 	$(MAKEINFO) $(SOURCES)
 
+$(PDFFILES): %.pdf: %.texi
+	$(TEXI2PDF) $<
+
 $(DVIFILES): %.dvi: %.texi
 	$(TEXI2DVI) $<
 
-dvi: $(DVIFILES) clean
+dvi: $(DVIFILES)
+	make clean
+
+pdf: $(PDFFILES)
+	make clean
 
 html:
 	$(PERL) $(TEXI2HTML) $(TEXI2FLAG) $(SOURCES)
@@ -43,7 +53,7 @@ clean:
 
 distclean:
 	'rm' -f *.aux *.cp *.fn *.ky *.log *.pg *.toc *.tp *.vr *.fns *.cps *.vrs
-	'rm' -f *.info *.dvi
+	'rm' -f *.info *.dvi *.pdf
 
 install:
 	cp $(INFOFILES) $(INFODIR)


### PR DESCRIPTION
- Add "make pdf" as a default option for the documentation.
- Remove auxiliary files when producing pdf or dvi output only after producing the output.
- Add .pdf, .vr, and .vrs files to .gitignore.